### PR TITLE
Implemented model scheduling

### DIFF
--- a/discoart/__init__.py
+++ b/discoart/__init__.py
@@ -98,11 +98,11 @@ def create(
         'ViT-B-16::openai',
         'RN50::openai',
     ],
-    clip_models_schedules: Optional[Dict[str, str]] = [
+    clip_models_schedules: Optional[Dict[str, str]] = {
         'ViT-B-32::openai': ALWAYS_SCHEDULED,
         'ViT-B-16::openai': ALWAYS_SCHEDULED,
         'RN50::openai': ALWAYS_SCHEDULED,
-    ],
+    },
     use_vertical_symmetry: Optional[bool] = False,
     use_horizontal_symmetry: Optional[bool] = False,
     transformation_percent: Optional[List[float]] = [0.09],

--- a/discoart/__init__.py
+++ b/discoart/__init__.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
 _clip_models_cache = {}
 
 
+ALWAYS_SCHEDULED = "[1] * 1000"
 # begin_create_overload
 
 
@@ -96,6 +97,11 @@ def create(
         'ViT-B-32::openai',
         'ViT-B-16::openai',
         'RN50::openai',
+    ],
+    clip_models_schedules: Optional[Dict[str, str]] = [
+        'ViT-B-32::openai': ALWAYS_SCHEDULED,
+        'ViT-B-16::openai': ALWAYS_SCHEDULED,
+        'RN50::openai': ALWAYS_SCHEDULED,
     ],
     use_vertical_symmetry: Optional[bool] = False,
     use_horizontal_symmetry: Optional[bool] = False,

--- a/discoart/helper.py
+++ b/discoart/helper.py
@@ -120,7 +120,7 @@ https://github.com/mlfoundations/open_clip#pretrained-model-interface
         if k not in enabled:
             clip_models.pop(k)
 
-    return list(clip_models.values())
+    return clip_models
 
 
 def load_all_models(


### PR DESCRIPTION
This modification allows models to be scheduled at different stages of the generation. The configuration style is the same as is used for cut_overview and cut_innercut

This proposal allows more finely-grained scheduling of models so that models with different characteristics can be run at different times. 

I haven't setup discoart on my dev machine so I haven't run this code. It is just a proof of concept. I have  started experimenting with this idea on another colab and I think there is merit in exploring model scheduling.