### PR TITLE
Move the cheatsheet() cell to its own .ipynb and !pip to %pip

### DIFF
--- a/discoart.ipynb
+++ b/discoart.ipynb
@@ -131,23 +131,7 @@
    "source": [
     "## Check parameter cheatsheet\n",
     "\n",
-    "But what parameters can be used in `create()`? just type `cheatsheet()` to lookup anytime:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2c6c8306",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from discoart import cheatsheet\n",
-    "\n",
-    "cheatsheet()"
+    "But what parameters can be used in `create()`? open [reference_sheet.ipynb](reference_sheet.ipynb) to see all parameters side-by-side while you work."
    ]
   },
   {

--- a/reference_sheet.ipynb
+++ b/reference_sheet.ipynb
@@ -34,6 +34,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f4e22757",
+   "metadata": {},
+   "source": [
+    "# You need discoart installed to use the cheatsheet."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "ca392ef6",
@@ -45,79 +53,6 @@
    "outputs": [],
    "source": [
     "%pip install -U discoart"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "47428f37",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "\n",
-    "---\n",
-    "\n",
-    "# Create artworks"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "78f39415",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from discoart import create\n",
-    "\n",
-    "da = create()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6269fd20",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "That's it. It is that simple."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d36983b6",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "# Specify parameters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fbf748c5",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from discoart import create\n",
-    "\n",
-    "da = create(text_prompts='A painting of sea cliffs in a tumultuous storm, Trending on ArtStation.',\n",
-    "       init_image='https://d2vyhzeko0lke5.cloudfront.net/2f4f6dfa5a05e078469ebe57e77b72f0.png',\n",
-    "       skip_steps=100)"
    ]
   },
   {
@@ -147,7 +82,7 @@
    "source": [
     "from discoart import cheatsheet\n",
     "\n",
-    "cheatsheet()"
+    "cheatsheet()\n"
    ]
   },
   {
@@ -167,7 +102,7 @@
     "\n",
     "---\n",
     "\n",
-    "## Visualize results\n",
+    "## Where your files go\n",
     "\n",
     "\n",
     "Final results and intermediate results are created under the current working directory, e.g.\n",
@@ -190,106 +125,6 @@
     "- `*-progress.gif` is the animated gif of all intermediate results so far.\n",
     "\n",
     "The save frequency is controlled by `save_rate`.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "df5020e4",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "## Export configs\n",
-    "\n",
-    "You can review its parameters from `da[0].tags` or export it as an SVG image:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0a190a7c",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from discoart.config import save_config_svg\n",
-    "\n",
-    "save_config_svg(da, 'my.svg')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fe0d4d89",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "## Pull results anywhere anytime\n",
-    "\n",
-    "At anytime on any machine, you can pull the real-time results (including paramters, intermedidate diffusion steps, final results) with a session ID:\n",
-    "\n",
-    "> Please replace `discoart-3205998582` to your own when you run the above 2 cells!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9db8e4e6",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from docarray import DocumentArray\n",
-    "\n",
-    "da = DocumentArray.pull('discoart-3205998582')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9ca59262",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "## Reuse a Document as initial state\n",
-    "\n",
-    "Consider a Document as a self-contained data with config and image, one can use it as the initial state for the future run. Its `.tags` will be used as the initial parameters; `.uri` if presented will be used as the initial image."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d29a95b0",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from discoart import create\n",
-    "from docarray import DocumentArray\n",
-    "\n",
-    "da = DocumentArray.pull('discoart-3205998582')\n",
-    "\n",
-    "create(init_document=da[0],\n",
-    "       cut_ic_pow=0.5,\n",
-    "       tv_scale=600, \n",
-    "       cut_overview='[12]*1000', \n",
-    "       cut_innercut='[12]*1000', \n",
-    "       use_secondary_model=False)"
    ]
   }
  ],


### PR DESCRIPTION
# Slight quality-of-life changes to the DiscoArt notebook/s

## Changing !pip to %pip

Changed !pip to %pip to make sure it's running in the current kernel.

## Separating the cheatsheet() cell into its own .ipynb notebook

Having the cheat sheet on the same page as the main functions resulted in excessive scrolling. One solution would be to have two versions of the notebook open, but this opens the user up to errors in using the wrong sheet if the main one loses focus or they simply mistake one for the other.  

I have included a functioning link in the main notebook to the cheat sheet notebook in the position previously held by the render code for the cheat sheet. 