### PR TITLE
Add option disable_progress_grid to user arguments

### DIFF
--- a/discoart/create.py
+++ b/discoart/create.py
@@ -80,6 +80,7 @@ def create(
     use_vertical_symmetry: Optional[bool] = False,
     visualize_cuts: Optional[bool] = False,
     width_height: Optional[List[int]] = [1280, 768],
+    disable_progress_grid: Optional[bool] = False,
 ) -> Optional['DocumentArray']:
 
     ...

--- a/discoart/persist.py
+++ b/discoart/persist.py
@@ -1,6 +1,5 @@
 import os
 import threading
-import base64
 from threading import Thread
 
 import torchvision.transforms.functional as TF

--- a/discoart/persist.py
+++ b/discoart/persist.py
@@ -1,5 +1,6 @@
 import os
 import threading
+import base64
 from threading import Thread
 
 import torchvision.transforms.functional as TF
@@ -99,18 +100,23 @@ def _save_progress_thread(*args):
     return t
 
 
-def _save_progress(da, da_gif, _nb, output_dir, fps, size_ratio):
+def _save_progress(da, da_gif, _nb, output_dir, fps, size_ratio, disable_progress_grid):
     with threading.Lock():
         try:
             for idx, d in enumerate(da):
                 if d.chunks:
-                    # only print the first image of the minibatch in progress
-                    d.chunks.plot_image_sprites(
-                        os.path.join(output_dir, f'{_nb}-progress-{idx}.png'),
-                        skip_empty=True,
-                        show_index=True,
-                        keep_aspect_ratio=True,
-                    )
+                    if disable_progress_grid:
+                        #save only the latest image
+                        file_name = os.path.join(output_dir, f'{_nb}-progress.png')
+                        d.load_uri_to_image_tensor().save_image_tensor_to_file(file_name)
+                    else:
+                        # only print the first image of the minibatch in progress
+                        d.chunks.plot_image_sprites(
+                            os.path.join(output_dir, f'{_nb}-progress-{idx}.png'),
+                            skip_empty=True,
+                            show_index=True,
+                            keep_aspect_ratio=True,
+                        )
             for idx, d_gif in enumerate(da_gif):
                 if d_gif.chunks and fps > 0:
                     d_gif.chunks.save_gif(

--- a/discoart/resources/default.yml
+++ b/discoart/resources/default.yml
@@ -63,3 +63,4 @@ truncate_overlength_prompt: False
 image_output: True
 visualize_cuts: False
 display_rate: 1
+disable_progress_grid: False

--- a/discoart/runner.py
+++ b/discoart/runner.py
@@ -453,6 +453,7 @@ scheduling tracking, please set `WANDB_MODE=online` before running/importing Dis
                                 output_dir,
                                 args.gif_fps,
                                 args.gif_size_ratio,
+                                args.disable_progress_grid,
                             )
                         )
 


### PR DESCRIPTION
Currently diffusion progress is saved as an [image sprite](https://docarray.jina.ai/datatypes/image/index.html#display-image-sprite) which is not very useful when running locally (not on a server or google collab) and when the save rate is high (i.e every frame) because it becomes hard to see how the image is looking as time goes on due to each snapshot getting smaller and smaller in the image sprite.

I propose adding an argument `disable_progress_grid` to settings.yml that will disable using `plot_image_sprites` and instead will just save the most recent snapshot using `save_image_tensor_to_file` with the file name `{_nb}-progress.png`

That way, at least on linux, we can just have `{_nb}-progress.png` open and we will see the updates properly at the right image resolution.

This pull requests implements this change. 